### PR TITLE
update community.webmonetization to interledger

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,7 +574,7 @@
                 <br><br>
                 If you’re looking to do something further with your Web Monetization code, check out the <strong>documentation</strong> <a href="https://webmonetization.org/docs/getting-started" target="_blank">here</a>.
                 <br><br>
-                It’s also great to <a href="https://community.webmonetization.org/" target="_blank">chat with other creators using Web Monetization</a> 
+                It’s also great to <a href="https://community.interledger.org/" target="_blank">chat with other creators in the Interledger Community</a> 
                 and engage in the <strong>community</strong> around it.
                 <br><br>
                 If you run a blog on <strong>WordPress</strong>, check <a href="https://wordpress.org/plugins/coil-web-monetization/" target="_blank">this</a> out 


### PR DESCRIPTION
The community forem has moved from `community.webmonetization.org` to [community.interledger.org](community.interledger.org). Updating our links to match.

I've tested each updated link to confirm they still work.